### PR TITLE
chore: add opened issues to GH project, link issues to PRs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add Opened Issue to Project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/zkitter/projects/1
+          github-token: ${{ secrets.TOKEN }}
+

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/zkitter/projects/1
-          github-token: ${{ secrets.TOKEN }}
+          github-token: ${{ secrets.TOKEN }} # specific access token different from GITHUB_TOKEN required (see https://github.com/marketplace/actions/add-to-github-projects#creating-a-pat-and-adding-it-to-your-repository)
 

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [opened]
 
+# set minimum required permissions for automatic `GITHUB_TOKEN` token
+permissions:
+  pull-requests: write
+  issues: read
+
 jobs:
   issue-links:
     name: Link PR to Issue
@@ -10,7 +15,6 @@ jobs:
     steps:
       - uses: tkt-actions/add-issue-links@v1.8.0
         with:
-          repo-token: ${{ secrets.TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           branch-prefix: 'issue-'
           resolve: true
- 

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -1,0 +1,16 @@
+name: Issue-PR Link
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  issue-links:
+    name: Link PR to Issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tkt-actions/add-issue-links@v1.8.0
+        with:
+          repo-token: ${{ secrets.TOKEN }}
+          branch-prefix: 'issue-'
+          resolve: true
+ 


### PR DESCRIPTION
Closes #13 

Add 2 new GH actions:
1. Add to [project](https://github.com/orgs/zkitter/projects/1/views/1)
  Based on [add-to-github-projects GH action](https://github.com/marketplace/actions/add-to-github-projects)
  All newly opened issues will be added to the project.
  Possible to set label filters and do the same for opened PRs if we want later
2. Link issues to PR:
  Based on [add-an-issue-link GH action](https://github.com/marketplace/actions/add-an-issue-link)  
  Any PR opened for a **branch prefixed with `issue-<number>`** will automatically be linked to the corresponding issue.  
  Provided the issue exists in the project (eg was added by previous action), the link will appear in the project board.  
  Merging the PR will close the issue.

_Note: linking the PR to the issue could actually be achieved manually like [this](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) too._

~~**REQUIRED: define a GH action `TOKEN`** secret with the following full permissions `repo` and `project` (see [doc](https://github.com/marketplace/actions/add-to-github-projects#creating-a-pat-and-adding-it-to-your-repository))~~
I added an organization `TOKEN` secret at org level.

## Test plan
You can test/try it out in this [repo](https://github.com/r1oga/repo-project-template)