### PR TITLE
feat: get list of retweets per post

### DIFF
--- a/src/models/posts.ts
+++ b/src/models/posts.ts
@@ -374,6 +374,22 @@ const posts = (sequelize: Sequelize) => {
     return values;
   };
 
+  const findAllRetweets = async (
+    messageId: string,
+    offset = 0,
+    limit = 20,
+    order: 'DESC' | 'ASC' = 'DESC'
+  ) => {
+    const result = await model.findAll({
+      where: { reference: messageId, subtype: 'REPOST' },
+      offset,
+      limit,
+      order: [['createdAt', order]],
+    });
+
+    return result.map((r: any) => r.toJSON().creator);
+  };
+
   const findLastTweetInConversation = async (id: string) => {
     const result = await model.findOne({
       where: {
@@ -482,6 +498,7 @@ const posts = (sequelize: Sequelize) => {
     findAllPosts,
     findAllRepliesFromCreator,
     findAllLikedPostsByCreator,
+    findAllRetweets,
     findLastTweetInConversation,
     findAllReplies,
     getHomeFeed,

--- a/src/services/http.test.ts
+++ b/src/services/http.test.ts
@@ -594,7 +594,7 @@ tape('HTTPService - get interep ID commitment', async t => {
 
   http.addRoutes();
 
-  const interepGetIdParams = getStub.args[27];
+  const interepGetIdParams = getStub.args[28];
   // @ts-ignore
   const getIdHandler: any = interepGetIdParams[2];
   const getIdRequest = newRequest({
@@ -686,7 +686,6 @@ tape.skip('HTTPService - get preview', async t => {
 });
 
 tape('HttpService - list all users who liked a post', async t => {
-  // const route = '/v1/post/:hash/likes';
   const http = new HttpService();
   const [, stubs] = stubCall(http);
   const res = newResponse();
@@ -701,7 +700,6 @@ tape('HttpService - list all users who liked a post', async t => {
 });
 
 tape('HttpService - get followers per user', async t => {
-  // const route = '/v1/post/:hash/likes';
   const http = new HttpService();
   const [, stubs] = stubCall(http);
   const res = newResponse();
@@ -716,7 +714,6 @@ tape('HttpService - get followers per user', async t => {
 });
 
 tape('HttpService - get followings per user', async t => {
-  // const route = '/v1/post/:hash/likes';
   const http = new HttpService();
   const [, stubs] = stubCall(http);
   const res = newResponse();
@@ -727,6 +724,20 @@ tape('HttpService - get followings per user', async t => {
   await http.handleGetUserFollowings(newRequest({ user: '0xr1oga' }, null, null), res);
 
   t.deepEqual(res.send.args[0][0].payload, followings, 'should be equal');
+  t.end();
+});
+
+tape('HttpService - get retweets per post', async t => {
+  const http = new HttpService();
+  const [, stubs] = stubCall(http);
+  const res = newResponse();
+  const retweets = ['0xfoo', '0xbar'];
+
+  stubs.posts.findAllRetweets.returns(Promise.resolve(retweets));
+
+  await http.handleGetRetweetsByPost(newRequest({ hash: '0x123/bar' }, null, null), res);
+
+  t.deepEqual(res.send.args[0][0].payload, retweets, 'should be equal');
   t.end();
 });
 

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -366,6 +366,15 @@ export default class HttpService extends GenericService {
     res.send(makeResponse(likers));
   };
 
+  handleGetRetweetsByPost = async (req: Request, res: Response) => {
+    const limit = req.query.limit && Number(req.query.limit);
+    const offset = req.query.offset && Number(req.query.offset);
+    const hash = req.params.hash;
+    const postsDB = await this.call('db', 'getPosts');
+    const retweets = await postsDB.findAllRetweets(hash, offset, limit);
+    res.send(makeResponse(retweets));
+  };
+
   handleGetUserFollowers = async (req: Request, res: Response) => {
     const limit = req.query.limit && Number(req.query.limit);
     const offset = req.query.offset && Number(req.query.offset);
@@ -648,6 +657,7 @@ export default class HttpService extends GenericService {
     this.app.get('/v1/homefeed', this.wrapHandler(this.handleGetHomefeed));
     this.app.get('/v1/post/:hash', this.wrapHandler(this.handleGetPostByHash));
     this.app.get('/v1/post/:hash/likes', this.wrapHandler(this.handleGetLikesByPost));
+    this.app.get('/v1/post/:hash/retweets', this.wrapHandler(this.handleGetRetweetsByPost));
 
     this.app.get('/v1/zkchat/users', this.wrapHandler(this.handleGetChatUsers));
     this.app.post(

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 import sinon, { SinonStub } from 'sinon';
+import Sinon from 'sinon';
 
 let fetchStub: any;
 export const stubFetch = () => {
@@ -42,6 +43,7 @@ export const stubCall = (
       findLastTweetInConversation: SinonStub;
       findAllRepliesFromCreator: SinonStub;
       findAllLikedPostsByCreator: SinonStub;
+      findAllRetweets: SinonStub;
       getHomeFeed: SinonStub;
       createTwitterPosts: SinonStub;
       findAllPosts: SinonStub;
@@ -159,6 +161,7 @@ export const stubCall = (
     findLastTweetInConversation: sinon.stub(),
     findAllRepliesFromCreator: sinon.stub(),
     findAllLikedPostsByCreator: sinon.stub(),
+    findAllRetweets: sinon.stub(),
     getHomeFeed: sinon.stub(),
     findAllPosts: sinon.stub(),
     findAllReplies: sinon.stub(),


### PR DESCRIPTION
Closes #24 

Add a new handler to get list of retweets on following routes:

|handler|route|description|
|---|---|---|
|`handleGetRetweetsByPost`|`/v1/post/:hash/retweets`|returns list of users who retweeted a post|

### Test Plan
- unit tests: `npm run test:some http`
- example of manual requests:
  - likes:
    ```
    curl -X GET --location "http://localhost:3000/v1/post/0xC7E20724c409d9E8e3181a559F4c529B17dc1Bd7%2F743a4230820f9b47bf3b37c0667e8222a9566cf9684647656213fae0eb8f8633/retweets?limit=10&offset=0"
    ```