### PR TITLE
refactor: use passport for twitter authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "@ensdomains/ensjs": "^2.0.1",
     "@interep/reputation": "^0.4.0",
+    "@superfaceai/passport-twitter-oauth2": "^1.2.0",
+    "@types/passport-twitter": "^1.0.37",
     "@zk-kit/identity": "^1.4.1",
     "@zk-kit/protocols": "^1.11.1",
     "async-mutex": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@ensdomains/ensjs': ^2.0.1
   '@interep/reputation': ^0.4.0
   '@istanbuljs/nyc-config-typescript': ^1.0.2
+  '@superfaceai/passport-twitter-oauth2': ^1.2.0
   '@types/cors': ^2.8.10
   '@types/elliptic': ^6.4.14
   '@types/express': ^4.17.11
@@ -15,6 +16,7 @@ specifiers:
   '@types/node': ^14.14.37
   '@types/passport': ^1.0.11
   '@types/passport-github2': ^1.2.5
+  '@types/passport-twitter': ^1.0.37
   '@types/sinon': ^10.0.11
   '@types/tape': ^4.13.2
   '@zk-kit/identity': ^1.4.1
@@ -76,6 +78,8 @@ specifiers:
 dependencies:
   '@ensdomains/ensjs': 2.1.0_3cxu5zja4e2r5wmvge7mdcljwq
   '@interep/reputation': 0.4.0
+  '@superfaceai/passport-twitter-oauth2': 1.2.0
+  '@types/passport-twitter': 1.0.37
   '@zk-kit/identity': 1.4.1_3cxu5zja4e2r5wmvge7mdcljwq
   '@zk-kit/protocols': 1.11.1_3cxu5zja4e2r5wmvge7mdcljwq
   async-mutex: 0.3.2
@@ -3352,6 +3356,15 @@ packages:
       }
     dev: true
 
+  /@superfaceai/passport-twitter-oauth2/1.2.0:
+    resolution:
+      {
+        integrity: sha512-B8VBjuY35bOFjyj4+fpSwsxYBjf1nPB5euxipImB7iFmBCDplTGIVlOL+Rf+/F2oJFSFsJKN+Uf5JtYUqy5ROg==,
+      }
+    dependencies:
+      passport-oauth2: 1.6.1
+    dev: false
+
   /@szmarczak/http-timer/4.0.6:
     resolution:
       {
@@ -3477,7 +3490,6 @@ packages:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 14.18.33
-    dev: true
 
   /@types/bson/4.0.5:
     resolution:
@@ -3516,7 +3528,6 @@ packages:
       }
     dependencies:
       '@types/node': 14.18.33
-    dev: true
 
   /@types/cors/2.8.12:
     resolution:
@@ -3580,7 +3591,6 @@ packages:
       '@types/node': 14.18.33
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
-    dev: true
 
   /@types/express-session/1.17.5:
     resolution:
@@ -3601,7 +3611,6 @@ packages:
       '@types/express-serve-static-core': 4.17.31
       '@types/qs': 6.9.7
       '@types/serve-static': 1.15.0
-    dev: true
 
   /@types/graceful-fs/4.1.5:
     resolution:
@@ -3723,7 +3732,6 @@ packages:
       {
         integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==,
       }
-    dev: true
 
   /@types/minimatch/3.0.5:
     resolution:
@@ -3815,6 +3823,16 @@ packages:
       '@types/passport': 1.0.11
     dev: true
 
+  /@types/passport-twitter/1.0.37:
+    resolution:
+      {
+        integrity: sha512-/FHODUP6ExYpRFdhVOtbHwVZRmni0kFyOFhOwqg61SoSwcED4c5tkhYu5cJElyhD5jbevRTmgInLFFI5s2hBag==,
+      }
+    dependencies:
+      '@types/express': 4.17.14
+      '@types/passport': 1.0.11
+    dev: false
+
   /@types/passport/1.0.11:
     resolution:
       {
@@ -3822,7 +3840,6 @@ packages:
       }
     dependencies:
       '@types/express': 4.17.14
-    dev: true
 
   /@types/pbkdf2/3.1.0:
     resolution:
@@ -3845,14 +3862,12 @@ packages:
       {
         integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==,
       }
-    dev: true
 
   /@types/range-parser/1.2.4:
     resolution:
       {
         integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==,
       }
-    dev: true
 
   /@types/responselike/1.0.0:
     resolution:
@@ -3887,7 +3902,6 @@ packages:
     dependencies:
       '@types/mime': 3.0.1
       '@types/node': 14.18.33
-    dev: true
 
   /@types/sinon/10.0.13:
     resolution:
@@ -10349,7 +10363,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,14 @@ import ZKChatService from './services/zkchat';
 import MerkleService from './services/merkle';
 import { ReputationService } from './services/reputation';
 import {
+  AuthController,
   EventsController,
-  GithubController,
   InterepController,
   MerkleController,
   MiscController,
   PostsController,
   TagsController,
-  TwitterController,
+  // TwitterController,
   UsersController,
   ZkChatController,
 } from './services/http/controllers';
@@ -36,6 +36,8 @@ import {
     main.add('gun', new GunService());
     main.add('ipfs', new IPFSService());
     main.add('http', new HttpService());
+
+    main.add('authController', new AuthController());
     main.add('interepController', new InterepController());
     main.add('eventsController', new EventsController());
     main.add('merkleController', new MerkleController());
@@ -43,9 +45,9 @@ import {
     main.add('postsController', new PostsController());
     main.add('usersController', new UsersController());
     main.add('tagsController', new TagsController());
-    main.add('twitterController', new TwitterController());
+    // main.add('twitterController', new TwitterController());
     main.add('zkChatController', new ZkChatController());
-    main.add('githubController', new GithubController());
+    // main.add('githubController', new GithubController());
     main.add('reputation', new ReputationService());
     await main.start();
   } catch (e) {

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,0 +1,38 @@
+import { Sequelize, STRING } from 'sequelize';
+
+export type AuthModel = {
+  userId: string;
+  provider: string;
+  username: string;
+  token: string;
+};
+
+const auth = (sequelize: Sequelize) => {
+  const model = sequelize.define(
+    'auth',
+    {
+      userId: { type: STRING },
+      provider: { type: STRING },
+      username: { type: STRING },
+      token: { type: STRING },
+    },
+    {
+      indexes: [{ unique: true, fields: ['userId'] }],
+    }
+  );
+
+  const findTokenByUserId = async (username: string) => {
+    const record = await model.findOne({ where: { username }, attributes: ['token'] });
+    return (record?.toJSON() as AuthModel | undefined)?.token;
+  };
+
+  const upsertOne = async (data: AuthModel) => (await model.upsert(data))[0];
+
+  return {
+    model,
+    findTokenByUserId,
+    upsertOne,
+  };
+};
+
+export default auth;

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -15,6 +15,7 @@ import linkPreview from '../../models/linkPreview';
 import ens from '../../models/ens';
 import twitterAuth from '../../models/twitterAuth';
 import githubAuth from '../../models/githubAuth';
+import auth from '../../models/auth';
 import interepGroups from '../../models/interepGroups';
 import semaphoreCreators from '../../models/semaphore_creators';
 import threads from '../../models/thread';
@@ -39,6 +40,7 @@ export default class DBService extends GenericService {
   semaphore?: ReturnType<typeof semaphore>;
   meta?: ReturnType<typeof meta>;
   userMeta?: ReturnType<typeof userMeta>;
+  auth?: ReturnType<typeof auth>;
   twitterAuth?: ReturnType<typeof twitterAuth>;
   githubAuth?: ReturnType<typeof githubAuth>;
   interepGroups?: ReturnType<typeof interepGroups>;
@@ -141,11 +143,11 @@ export default class DBService extends GenericService {
     return this.githubAuth;
   }
 
-  async getAuthDb(provider: 'github' /* 'twitter' | 'reddit' */) {
-    switch (provider) {
-      case 'github':
-        return this.getGithubAuth();
+  async getAuth() {
+    if (!this.auth) {
+      return Promise.reject(new Error('auth is not initialized'));
     }
+    return this.auth;
   }
 
   async getApp(): Promise<ReturnType<typeof app>> {
@@ -220,6 +222,7 @@ export default class DBService extends GenericService {
     this.ens = ens(this.sequelize);
     this.twitterAuth = twitterAuth(this.sequelize);
     this.githubAuth = githubAuth(this.sequelize);
+    this.auth = auth(this.sequelize);
     this.interepGroups = interepGroups(this.sequelize);
     this.semaphoreCreators = semaphoreCreators(this.sequelize);
     this.threads = threads(this.sequelize);
@@ -244,6 +247,7 @@ export default class DBService extends GenericService {
     await this.ens?.model.sync({ force: !!process.env.FORCE });
     await this.twitterAuth?.model.sync({ force: !!process.env.FORCE });
     await this.githubAuth?.model.sync({ force: !!process.env.FORCE });
+    await this.auth?.model.sync({ force: !!process.env.FORCE });
     await this.interepGroups?.model.sync({ force: !!process.env.FORCE });
     await this.semaphoreCreators?.model.sync({ force: !!process.env.FORCE });
     await this.threads?.model.sync({ force: !!process.env.FORCE });
@@ -262,6 +266,7 @@ export default class DBService extends GenericService {
 
     await this.app?.updateLastGroup42BlockScanned(7660170);
   }
+
   async stop() {
     await this.sequelize.close();
   }

--- a/src/services/http/controllers/Auth.ts
+++ b/src/services/http/controllers/Auth.ts
@@ -1,0 +1,140 @@
+import { Request, RequestHandler, Response, Router } from 'express';
+import passport from 'passport';
+import { Strategy as GhStrategy } from 'passport-github2';
+import { Strategy as TwitterStrategy } from '@superfaceai/passport-twitter-oauth2';
+import { calculateReputation, OAuthProvider } from '@interep/reputation';
+
+import { Controller } from './interface';
+import config from '../../../util/config';
+import { getReceivedStars } from '../../../util/github';
+
+const { ghCallbackUrl, ghClientId, ghClientSecret, twCallbackUrl, twClientId, twClientSecret } =
+  config;
+
+type GhProfile = {
+  id: string;
+  provider: string;
+  username: string;
+  _json: {
+    followers: number;
+    plan: { name: string };
+  };
+};
+
+type TwProfile = {
+  id: string;
+  username: string;
+};
+
+export class AuthController extends Controller {
+  prefix = '/auth';
+  redirectUrl: string;
+
+  constructor() {
+    super();
+    passport.use(
+      new GhStrategy(
+        {
+          clientID: ghClientId,
+          clientSecret: ghClientSecret,
+          callbackURL: ghCallbackUrl,
+        },
+        async (accessToken: string, refreshToken: string, profile: GhProfile, done: any) => {
+          const {
+            id: userId,
+            provider,
+            username,
+            _json: {
+              followers,
+              plan: { name: planName },
+            },
+          } = profile;
+
+          const proPlan = planName === 'pro';
+          const receivedStars = await getReceivedStars(username);
+          const reputation = calculateReputation(OAuthProvider.GITHUB, {
+            followers,
+            receivedStars,
+            proPlan,
+          });
+
+          const db = await this.call('db', 'getAuth');
+
+          await db.upsertOne({ provider, userId, username, token: accessToken });
+
+          return done(null, {
+            provider,
+            username,
+            reputation,
+          });
+        }
+      )
+    );
+
+    passport.use(
+      // @ts-ignore
+      new TwitterStrategy(
+        {
+          clientType: 'public',
+          clientID: twClientId,
+          clientSecret: twClientSecret,
+          callbackURL: twCallbackUrl,
+        },
+        async (accessToken, refreshToken, profile, done) => {
+          const { provider, id: userId, username } = profile;
+
+          const db = await this.call('db', 'getAuth');
+
+          await db.upsertOne({ provider, userId, username, token: accessToken });
+
+          // TODO get twitter followers/reputation
+          // @ts-ignore
+          return done(null, {
+            provider,
+            username,
+            // reputation,
+          });
+        }
+      )
+    );
+
+    this.addRoutes();
+  }
+
+  addRoutes = () => {
+    this._router.use(
+      '/github',
+      Router()
+        .get(
+          '',
+          this.storeRedirectUrl,
+          passport.authenticate('github', { scope: ['read:user', 'read:org'] })
+        )
+        .get('/callback', passport.authenticate('github'), this.callback)
+        .get('/test', (req, res) => {
+          res.json(req.user);
+        })
+    );
+
+    this._router.use(
+      '/twitter',
+      Router()
+        .get(
+          '',
+          this.storeRedirectUrl,
+          passport.authenticate('twitter', { scope: ['follows.read'] })
+        )
+        .get('/callback', passport.authenticate('twitter'), this.callback)
+    );
+  };
+
+  callback = (req: Request, res: Response) => {
+    console.log(req.user);
+    res.redirect(this.redirectUrl);
+  };
+
+  storeRedirectUrl: RequestHandler<{}, {}, {}, { redirectUrl: string }> = (req, res, next) => {
+    this.redirectUrl = req.query.redirectUrl;
+    next();
+  };
+}

--- a/src/services/http/controllers/index.ts
+++ b/src/services/http/controllers/index.ts
@@ -1,3 +1,4 @@
+export * from './Auth';
 export * from './Events';
 export * from './Github';
 export * from './Interep';

--- a/src/services/http/index.ts
+++ b/src/services/http/index.ts
@@ -20,14 +20,14 @@ export default class HttpService extends GenericService {
   httpServer: any;
 
   controllers = [
+    'auth',
     'events',
-    'github',
     'interep',
     'merkle',
     'misc',
     'posts',
     'tags',
-    'twitter',
+    // 'twitter',
     'users',
     'zkChat',
   ];
@@ -65,9 +65,9 @@ export default class HttpService extends GenericService {
     });
     passport.deserializeUser(
       (user: { username: string; provider: string; reputation: string }, done) => {
-        this.call('db', 'getAuthDb', user.provider)
+        this.call('db', 'getAuth')
           .then(db => {
-            db.findTokenByUsername(user.username)
+            db.findTokenByUserId(user.username)
               .then((token: string | undefined) => {
                 // @ts-ignore
                 done(null, { token, ...user });

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -29,6 +29,8 @@ let json: {
   ghClientSecret?: string;
   twCallbackUrl?: string;
   twConsumerKey?: string;
+  twClientId?: string; // OAuth 2.0 Client ID in twitter dev portal
+  twClientSecret?: string; // OAuth 2.0 Client Secret in twitter dev portal
   twConsumerSecret?: string;
   twBearerToken?: string;
   twAccessKey?: string;
@@ -54,6 +56,8 @@ const ghCallbackUrl = json.ghCallbackUrl || process.env.GH_CALLBACK_URL;
 const ghClientId = json.ghClientId || process.env.GH_CLIENT_ID;
 const ghClientSecret = json.ghClientSecret || process.env.GH_CLIENT_SECRET;
 const twCallbackUrl = json.twCallbackUrl || process.env.TW_CALLBACK_URL;
+const twClientId = json.twClientId || process.env.TW_CLIENT_ID;
+const twClientSecret = json.twClientSecret || process.env.TW_CLIENT_SECRET;
 const twConsumerKey = json.twConsumerKey || process.env.TW_CONSUMER_KEY;
 const twConsumerSecret = json.twConsumerSecret || process.env.TW_CONSUMER_SECRET;
 const twBearerToken = json.twBearerToken || process.env.TW_BEARER_TOKEN;
@@ -99,6 +103,8 @@ if (!ghCallbackUrl) throw new Error(`ghCallbackUrl config missing`);
 if (!ghClientId) throw new Error(`ghClientId config missing`);
 if (!ghClientSecret) throw new Error(`ghClientSecret config missing`);
 if (!twCallbackUrl) throw new Error(`twCallbackUrl is not valid`);
+if (!twClientId) throw new Error(`twClientId is not valid`);
+if (!twClientSecret) throw new Error(`twClientSecret is not valid`);
 if (!twConsumerKey) throw new Error(`twConsumerKey is not valid`);
 if (!twConsumerSecret) throw new Error(`twConsumerSecret is not valid`);
 if (!twBearerToken) throw new Error(`twBearerToken is not valid`);
@@ -133,6 +139,8 @@ const config = {
   ghClientId,
   ghClientSecret,
   twCallbackUrl,
+  twClientId,
+  twClientSecret,
   twConsumerKey,
   twConsumerSecret,
   twBearerToken,


### PR DESCRIPTION
Refactor twitter auth endpoints to use passport like GIthub.  
Define a common `auth` DB model.

# Related issue

- Resolve #60